### PR TITLE
Cacher 2.0

### DIFF
--- a/Cacher
+++ b/Cacher
@@ -3,7 +3,7 @@
 # This script will process Caching Server Debug Logs and e-mail the information to relevant parties
 # through the use of Apple's Server Alert mechanism.
 ## Written by Erik Gomez with help from Google Search.
-## Last Modified 09/23/2016
+## Last Modified 09/29/2016
 
 ## Variables
 version='2.0'
@@ -333,10 +333,16 @@ egrep --only-matching -E ''9'\.(3)$' "${tmplocation}"/Total_iOS.txt > "${tmploca
 egrep -o "(9.3.1)" "${tmplocation}"/Total_iOS.txt > "${tmplocation}"/iOS_9.3.1.txt
 ## Look for only "9.3.2" and output
 egrep -o "(9.3.2)" "${tmplocation}"/Total_iOS.txt > "${tmplocation}"/iOS_9.3.2.txt
+## Look for only "9.3.3" and output
+egrep -o "(9.3.3)" "${tmplocation}"/Total_iOS.txt > "${tmplocation}"/iOS_9.3.3.txt
+## Look for only "9.3.4" and output
+egrep -o "(9.3.4)" "${tmplocation}"/Total_iOS.txt > "${tmplocation}"/iOS_9.3.4.txt
+## Look for only "9.3.5" and output
+egrep -o "(9.3.5)" "${tmplocation}"/Total_iOS.txt > "${tmplocation}"/iOS_9.3.5.txt
 ### iOS 10
 ## Look for only "10.0.1" and output
 egrep -o "(10.0.1)" "${tmplocation}"/Total_iOS.txt > "${tmplocation}"/iOS_10.0.1.txt
-## Look for only "10.0.1" and output
+## Look for only "10.0.2" and output
 egrep -o "(10.0.2)" "${tmplocation}"/Total_iOS.txt > "${tmplocation}"/iOS_10.0.2.txt
 
 ## Use wc to count the lines from each file to give you a reasonable estimate of total numbers.
@@ -362,6 +368,9 @@ totalios921number=`wc -l "${tmplocation}"/iOS_9.2.1.txt | awk '{print $1}'`
 totalios930number=`wc -l "${tmplocation}"/iOS_9.3.txt | awk '{print $1}'`
 totalios931number=`wc -l "${tmplocation}"/iOS_9.3.1.txt | awk '{print $1}'`
 totalios932number=`wc -l "${tmplocation}"/iOS_9.3.2.txt | awk '{print $1}'`
+totalios933number=`wc -l "${tmplocation}"/iOS_9.3.3.txt | awk '{print $1}'`
+totalios934number=`wc -l "${tmplocation}"/iOS_9.3.4.txt | awk '{print $1}'`
+totalios935number=`wc -l "${tmplocation}"/iOS_9.3.5.txt | awk '{print $1}'`
 ### iOS 10
 totalios1001number=`wc -l "${tmplocation}"/iOS_10.0.1.txt | awk '{print $1}'`
 totalios1002number=`wc -l "${tmplocation}"/iOS_10.0.2.txt | awk '{print $1}'`
@@ -525,6 +534,9 @@ echo "  $totalios921number iOS 9.2.1 Devices" 2>&1 | tee -a "${tmplocation}"/Ale
 echo "  $totalios930number iOS 9.3 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 echo "  $totalios931number iOS 9.3.1 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 echo "  $totalios932number iOS 9.3.2 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "  $totalios933number iOS 9.3.3 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "  $totalios934number iOS 9.3.4 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "  $totalios935number iOS 9.3.5 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 echo "  $totalios1001number iOS 10.0.1 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 echo "  $totalios1002number iOS 10.0.2 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 echo 
@@ -600,56 +612,7 @@ echo  " " 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 ## Anything containing the phrase "%Darwin" means it is OS X related. Read the merged log and output to new file
 egrep -o "(\s(Darwin\S+))" "${tmplocation}"/URL_Log-"${yesterday}".log | cut -d " " -f 2 > "${tmplocation}"/Total_OS_X.txt
 
-#Apple devices running 10.8.2 and above automatically use a nearby caching server if available; Uncomment previous versions if you want them in your reports
-### OS X 10.5 Leopard
-#egrep -o "(\/(9.0.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.5.0.txt
-#egrep -o "(\/(9.1.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.5.1.txt
-#egrep -o "(\/(9.2.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.5.2.txt
-#egrep -o "(\/(9.3.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.5.3.txt
-#egrep -o "(\/(9.4.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.5.4.txt
-#egrep -o "(\/(9.5.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.5.5.txt
-#egrep -o "(\/(9.6.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.5.6.txt
-#egrep -o "(\/(9.7.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.5.7.txt
-#egrep -o "(\/(9.8.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.5.8.txt
-### OS X 10.6 Snow Leopard
-#egrep -o "(\/(10.0.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.6.0.txt
-#egrep -o "(\/(10.1.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.6.1.txt
-#egrep -o "(\/(10.2.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.6.2.txt
-#egrep -o "(\/(10.3.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.6.3.txt
-#egrep -o "(\/(10.4.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.6.4.txt
-#egrep -o "(\/(10.5.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.6.5.txt
-#egrep -o "(\/(10.6.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.6.6.txt
-#egrep -o "(\/(10.7.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.6.7.txt
-#egrep -o "(\/(10.8.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.6.8.txt
-### OS X 10.7 Lion
-# 10.7.0 remained the same version number with Darwin release 11.0.0 and 11.0.2
-#egrep -o "(\/(11.0.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.7.0.txt
-#egrep -o "(\/(11.0.2))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.7.0_1.txt
-#egrep -o "(\/(11.1.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.7.1.txt
-#egrep -o "(\/(11.2.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.7.2.txt
-#egrep -o "(\/(11.3.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.7.3.txt
-#egrep -o "(\/(11.4.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.7.4.txt
-#egrep -o "(\/(11.4.2))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.7.5.txt
-### OS X 10.8 Mountain Lion
-#egrep -o "(\/(12.0.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.8.0.txt
-#egrep -o "(\/(12.1.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.8.1.txt
-egrep -o "(\/(12.2.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.8.2.txt
-egrep -o "(\/(12.3.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.8.3.txt
-egrep -o "(\/(12.4.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.8.4.txt
-egrep -o "(\/(12.5.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.8.5.txt
-### OS X 10.9 Mavericks
-# Cannot distinguish 10.9.0 from 10.9.1
-egrep -o "(\/(13.0.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.9.0.txt
-egrep -o "(\/(13.1.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.9.2.txt
-egrep -o "(\/(13.2.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.9.3.txt
-egrep -o "(\/(13.3.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.9.4.txt
-egrep -o "(\/(13.4.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.9.5.txt
-### OS X 10.10 Yosemite
-# Cannot distinguish 10.10.0 from 10.10.1
-egrep -o "(\/(14.0.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.10.0.txt
-egrep -o "(\/(14.1.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.10.2.txt
-egrep -o "(\/(14.3.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.10.3.txt
-egrep -o "(\/(14.4.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.10.4.txt
+### OS X 10.10 Yosemite (Last release only [10.10.5])
 egrep -o "(\/(14.5.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.10.5.txt
 ### OS X 10.11 El Capitan
 # Cannot distinguish 10.11 from 10.11.1; OS X was not released with Darwin 15.1.
@@ -664,56 +627,7 @@ egrep -o "(\/(16.0.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total
 
 ## Use wc to count the lines from each file to give you a reasonable estimate of total numbers.
 totalosxnumber=`wc -l "${tmplocation}"/Total_OS_X.txt | awk '{print $1}'`
-### OS X 10.5 Leopard
-#total1050number=`wc -l "${tmplocation}"/Total_OS_X_10.5.0.txt | awk '{print $1}'`
-#total1051number=`wc -l "${tmplocation}"/Total_OS_X_10.5.1.txt | awk '{print $1}'`
-#total1052number=`wc -l "${tmplocation}"/Total_OS_X_10.5.2.txt | awk '{print $1}'`
-#total1053number=`wc -l "${tmplocation}"/Total_OS_X_10.5.3.txt | awk '{print $1}'`
-#total1054number=`wc -l "${tmplocation}"/Total_OS_X_10.5.4.txt | awk '{print $1}'`
-#total1055number=`wc -l "${tmplocation}"/Total_OS_X_10.5.5.txt | awk '{print $1}'`
-#total1056number=`wc -l "${tmplocation}"/Total_OS_X_10.5.6.txt | awk '{print $1}'`
-#total1057number=`wc -l "${tmplocation}"/Total_OS_X_10.5.7.txt | awk '{print $1}'`
-#total1058number=`wc -l "${tmplocation}"/Total_OS_X_10.5.8.txt | awk '{print $1}'`
-### OS X 10.6 Snow Leopard
-#total1060number=`wc -l "${tmplocation}"/Total_OS_X_10.6.0.txt | awk '{print $1}'`
-#total1061number=`wc -l "${tmplocation}"/Total_OS_X_10.6.1.txt | awk '{print $1}'`
-#total1062number=`wc -l "${tmplocation}"/Total_OS_X_10.6.2.txt | awk '{print $1}'`
-#total1063number=`wc -l "${tmplocation}"/Total_OS_X_10.6.3.txt | awk '{print $1}'`
-#total1064number=`wc -l "${tmplocation}"/Total_OS_X_10.6.4.txt | awk '{print $1}'`
-#total1065number=`wc -l "${tmplocation}"/Total_OS_X_10.6.5.txt | awk '{print $1}'`
-#total1066number=`wc -l "${tmplocation}"/Total_OS_X_10.6.6.txt | awk '{print $1}'`
-#total1067number=`wc -l "${tmplocation}"/Total_OS_X_10.6.7.txt | awk '{print $1}'`
-#total1068number=`wc -l "${tmplocation}"/Total_OS_X_10.6.8.txt | awk '{print $1}'`
-### OS X 10.7 Lion
-# 10.7.0 remained the same version number with Darwin release 11.0.0 and 11.0.2
-#total1070number=`wc -l "${tmplocation}"/Total_OS_X_10.7.0.txt | awk '{print $1}'`
-#total10701number=`wc -l "${tmplocation}"/Total_OS_X_10.7.0_1.txt | awk '{print $1}'`
-#total1071number=`wc -l "${tmplocation}"/Total_OS_X_10.7.1.txt | awk '{print $1}'`
-#total1072number=`wc -l "${tmplocation}"/Total_OS_X_10.7.2.txt | awk '{print $1}'`
-#total1073number=`wc -l "${tmplocation}"/Total_OS_X_10.7.3.txt | awk '{print $1}'`
-#total1074number=`wc -l "${tmplocation}"/Total_OS_X_10.7.4.txt | awk '{print $1}'`
-#total1075number=`wc -l "${tmplocation}"/Total_OS_X_10.7.5.txt | awk '{print $1}'`
-### OS X 10.8 Mountain Lion
-#total1080number=`wc -l "${tmplocation}"/Total_OS_X_10.8.0.txt | awk '{print $1}'`
-#total1081number=`wc -l "${tmplocation}"/Total_OS_X_10.8.1.txt | awk '{print $1}'`
-total1082number=`wc -l "${tmplocation}"/Total_OS_X_10.8.2.txt | awk '{print $1}'`
-total1083number=`wc -l "${tmplocation}"/Total_OS_X_10.8.3.txt | awk '{print $1}'`
-total1084number=`wc -l "${tmplocation}"/Total_OS_X_10.8.4.txt | awk '{print $1}'`
-total1085number=`wc -l "${tmplocation}"/Total_OS_X_10.8.5.txt | awk '{print $1}'`
-### OS X 10.9 Mavericks
-# Cannot distinguish 10.9.0 from 10.9.1
-total1090number=`wc -l "${tmplocation}"/Total_OS_X_10.9.0.txt | awk '{print $1}'`
-total1091number=`wc -l "${tmplocation}"/Total_OS_X_10.9.1.txt | awk '{print $1}'`
-total1092number=`wc -l "${tmplocation}"/Total_OS_X_10.9.2.txt | awk '{print $1}'`
-total1093number=`wc -l "${tmplocation}"/Total_OS_X_10.9.3.txt | awk '{print $1}'`
-total1094number=`wc -l "${tmplocation}"/Total_OS_X_10.9.4.txt | awk '{print $1}'`
-total1095number=`wc -l "${tmplocation}"/Total_OS_X_10.9.5.txt | awk '{print $1}'`
-### OS X 10.10 Yosemite
-# Cannot distinguish 10.10.0 from 10.10.1
-total10100number=`wc -l "${tmplocation}"/Total_OS_X_10.10.0.txt | awk '{print $1}'`
-total10102number=`wc -l "${tmplocation}"/Total_OS_X_10.10.2.txt | awk '{print $1}'`
-total10103number=`wc -l "${tmplocation}"/Total_OS_X_10.10.3.txt | awk '{print $1}'`
-total10104number=`wc -l "${tmplocation}"/Total_OS_X_10.10.4.txt | awk '{print $1}'`
+### OS X 10.10 Yosemite (Last release only [10.10.5])
 total10105number=`wc -l "${tmplocation}"/Total_OS_X_10.10.5.txt | awk '{print $1}'`
 ### OS X 10.11 El Capitan
 # Cannot distinguish 10.11 from 10.11.1; OS X was not released with Darwin 15.1.
@@ -728,46 +642,6 @@ total10120number=`wc -l "${tmplocation}"/Total_OS_X_10.12.0.txt | awk '{print $1
 
 ## Output Darwin data.
 echo "A total of $totalosxnumber OS X devices hit the Caching Server yesterday consisting of:" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
-#echo "  $total1050number OS X Leopard 10.5.0 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
-#echo "  $total1051number OS X Leopard 10.5.1 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
-#echo "  $total1052number OS X Leopard 10.5.2 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
-#echo "  $total1053number OS X Leopard 10.5.3 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
-#echo "  $total1054number OS X Leopard 10.5.4 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
-#echo "  $total1055number OS X Leopard 10.5.5 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
-#echo "  $total1056number OS X Leopard 10.5.6 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
-#echo "  $total1057number OS X Leopard 10.5.7 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
-#echo "  $total1058number OS X Leopard 10.5.8 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
-#echo "  $total1060number OS X Snow Leopard 10.6.0 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
-#echo "  $total1061number OS X Snow Leopard 10.6.1 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
-#echo "  $total1062number OS X Snow Leopard 10.6.2 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
-#echo "  $total1063number OS X Snow Leopard 10.6.3 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
-#echo "  $total1064number OS X Snow Leopard 10.6.4 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
-#echo "  $total1065number OS X Snow Leopard 10.6.5 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
-#echo "  $total1066number OS X Snow Leopard 10.6.6 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
-#echo "  $total1067number OS X Snow Leopard 10.6.7 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
-#echo "  $total1068number OS X Snow Leopard 10.6.8 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
-#echo "  $total1070number OS X Lion 10.7.0 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
-#echo "  $total10701number OS X Lion 10.7.0_1 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
-#echo "  $total1071number OS X Lion 10.7.1 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
-#echo "  $total1072number OS X Lion 10.7.2 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
-#echo "  $total1073number OS X Lion 10.7.3 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
-#echo "  $total1074number OS X Lion 10.7.4 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
-#echo "  $total1075number OS X Lion 10.7.5 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
-#echo "  $total1080number OS X Mountain Lion 10.8.0 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
-#echo "  $total1081number OS X Mountain Lion 10.8.1 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
-echo "  $total1082number OS X Mountain Lion 10.8.2 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
-echo "  $total1083number OS X Mountain Lion 10.8.3 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
-echo "  $total1084number OS X Mountain Lion 10.8.4 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
-echo "  $total1085number OS X Mountain Lion 10.8.5 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
-echo "  $total1090number OS X Mavericks 10.9.0/10.9.0.1 Devices [Cannot distinguish between builds]" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
-echo "  $total1092number OS X Mavericks 10.9.2 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
-echo "  $total1093number OS X Mavericks 10.9.3 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
-echo "  $total1094number OS X Mavericks 10.9.4 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
-echo "  $total1095number OS X Mavericks 10.9.5 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
-echo "  $total10100number OS X Yosemite 10.10.0/10.10.1 Devices [Cannot distinguish between builds]" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
-echo "  $total10102number OS X Yosemite 10.10.2 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
-echo "  $total10103number OS X Yosemite 10.10.3 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
-echo "  $total10104number OS X Yosemite 10.10.4 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 echo "  $total10105number OS X Yosemite 10.10.5 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 echo "  $total10110number OS X El Capitan 10.11.0/10.11.1 Devices [Cannot distinguish between builds]" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 echo "  $total10112number OS X El Capitan 10.11.2 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt

--- a/Cacher
+++ b/Cacher
@@ -336,6 +336,8 @@ egrep -o "(9.3.2)" "${tmplocation}"/Total_iOS.txt > "${tmplocation}"/iOS_9.3.2.t
 ### iOS 10
 ## Look for only "10.0.1" and output
 egrep -o "(10.0.1)" "${tmplocation}"/Total_iOS.txt > "${tmplocation}"/iOS_10.0.1.txt
+## Look for only "10.0.1" and output
+egrep -o "(10.0.2)" "${tmplocation}"/Total_iOS.txt > "${tmplocation}"/iOS_10.0.2.txt
 
 ## Use wc to count the lines from each file to give you a reasonable estimate of total numbers.
 ### iOS 8
@@ -362,6 +364,7 @@ totalios931number=`wc -l "${tmplocation}"/iOS_9.3.1.txt | awk '{print $1}'`
 totalios932number=`wc -l "${tmplocation}"/iOS_9.3.2.txt | awk '{print $1}'`
 ### iOS 10
 totalios1001number=`wc -l "${tmplocation}"/iOS_10.0.1.txt | awk '{print $1}'`
+totalios1002number=`wc -l "${tmplocation}"/iOS_10.0.2.txt | awk '{print $1}'`
 
 ## Anything containing the phrase "%model" means it is model type related. Read the merged log and output to new file
 egrep -o "(\s(model\S+))" "${tmplocation}"/URL_Log-"${yesterday}".log | cut -d " " -f 2 > "${tmplocation}"/Total_models.txt
@@ -421,6 +424,14 @@ totaliphone81=`egrep -o "(iPhone8,1)" "${tmplocation}"/Total_models.txt | wc -l 
 totaliphone82=`egrep -o "(iPhone8,2)" "${tmplocation}"/Total_models.txt | wc -l | awk '{print $1}'`
 ## Look for "iPhone8,4" and output
 totaliphone84=`egrep -o "(iPhone8,4)" "${tmplocation}"/Total_models.txt | wc -l | awk '{print $1}'`
+## Look for "iPhone9,1" and output
+totaliphone91=`egrep -o "(iPhone9,1)" "${tmplocation}"/Total_models.txt | wc -l | awk '{print $1}'`
+## Look for "iPhone9,2" and output
+totaliphone92=`egrep -o "(iPhone9,2)" "${tmplocation}"/Total_models.txt | wc -l | awk '{print $1}'`
+## Look for "iPhone9,3" and output
+totaliphone93=`egrep -o "(iPhone9,3)" "${tmplocation}"/Total_models.txt | wc -l | awk '{print $1}'`
+## Look for "iPhone9,4" and output
+totaliphone94=`egrep -o "(iPhone9,4)" "${tmplocation}"/Total_models.txt | wc -l | awk '{print $1}'`
 
 ## Device Identifiers iPad (Only 2,1 and higher can run iOS 8)
 ## Look for "iPad2,1" and output
@@ -515,6 +526,7 @@ echo "  $totalios930number iOS 9.3 Devices" 2>&1 | tee -a "${tmplocation}"/Alert
 echo "  $totalios931number iOS 9.3.1 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 echo "  $totalios932number iOS 9.3.2 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 echo "  $totalios1001number iOS 10.0.1 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "  $totalios1002number iOS 10.0.2 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 echo 
 echo  " " 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 ## iOS Model Breakdown
@@ -541,6 +553,10 @@ echo "    $totaliphone71 iPhone 6 Plus" 2>&1 | tee -a "${tmplocation}"/AlertInfo
 echo "    $totaliphone81 iPhone 6S" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 echo "    $totaliphone82 iPhone 6S Plus" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 echo "    $totaliphone84 iPhone SE" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "    $totaliphone91 iPhone 7" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "    $totaliphone92 iPhone 7 Plus" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "    $totaliphone93 iPhone 7 ?" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "    $totaliphone94 iPhone 7 Plus ?" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 ### iPads
 echo "  $totalipadnumber Total iPads" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 echo "    $totalipad21 iPad 2nd Generation [Wifi]" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
@@ -584,46 +600,170 @@ echo  " " 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 ## Anything containing the phrase "%Darwin" means it is OS X related. Read the merged log and output to new file
 egrep -o "(\s(Darwin\S+))" "${tmplocation}"/URL_Log-"${yesterday}".log | cut -d " " -f 2 > "${tmplocation}"/Total_OS_X.txt
 
+#Apple devices running 10.8.2 and above automatically use a nearby caching server if available; Uncomment previous versions if you want them in your reports
+### OS X 10.5 Leopard
+#egrep -o "(\/(9.0.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.5.0.txt
+#egrep -o "(\/(9.1.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.5.1.txt
+#egrep -o "(\/(9.2.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.5.2.txt
+#egrep -o "(\/(9.3.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.5.3.txt
+#egrep -o "(\/(9.4.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.5.4.txt
+#egrep -o "(\/(9.5.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.5.5.txt
+#egrep -o "(\/(9.6.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.5.6.txt
+#egrep -o "(\/(9.7.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.5.7.txt
+#egrep -o "(\/(9.8.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.5.8.txt
+### OS X 10.6 Snow Leopard
+#egrep -o "(\/(10.0.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.6.0.txt
+#egrep -o "(\/(10.1.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.6.1.txt
+#egrep -o "(\/(10.2.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.6.2.txt
+#egrep -o "(\/(10.3.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.6.3.txt
+#egrep -o "(\/(10.4.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.6.4.txt
+#egrep -o "(\/(10.5.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.6.5.txt
+#egrep -o "(\/(10.6.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.6.6.txt
+#egrep -o "(\/(10.7.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.6.7.txt
+#egrep -o "(\/(10.8.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.6.8.txt
+### OS X 10.7 Lion
+# 10.7.0 remained the same version number with Darwin release 11.0.0 and 11.0.2
+#egrep -o "(\/(11.0.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.7.0.txt
+#egrep -o "(\/(11.0.2))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.7.0_1.txt
+#egrep -o "(\/(11.1.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.7.1.txt
+#egrep -o "(\/(11.2.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.7.2.txt
+#egrep -o "(\/(11.3.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.7.3.txt
+#egrep -o "(\/(11.4.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.7.4.txt
+#egrep -o "(\/(11.4.2))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.7.5.txt
+### OS X 10.8 Mountain Lion
+#egrep -o "(\/(12.0.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.8.0.txt
+#egrep -o "(\/(12.1.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.8.1.txt
+egrep -o "(\/(12.2.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.8.2.txt
+egrep -o "(\/(12.3.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.8.3.txt
+egrep -o "(\/(12.4.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.8.4.txt
+egrep -o "(\/(12.5.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.8.5.txt
+### OS X 10.9 Mavericks
+# Cannot distinguish 10.9.0 from 10.9.1
+egrep -o "(\/(13.0.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.9.0.txt
+egrep -o "(\/(13.1.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.9.2.txt
+egrep -o "(\/(13.2.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.9.3.txt
+egrep -o "(\/(13.3.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.9.4.txt
+egrep -o "(\/(13.4.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.9.5.txt
 ### OS X 10.10 Yosemite
-## Look for "14.0.0" and output (10.10.0 and sadly 10.10.1)
-egrep -o "(\/(14.0.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.10.0_1.txt
-## Look for "14.1.0" and output (10.10.2 *sigh*)
+# Cannot distinguish 10.10.0 from 10.10.1
+egrep -o "(\/(14.0.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.10.0.txt
 egrep -o "(\/(14.1.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.10.2.txt
-## Look for "14.3.0" and output (10.10.3 look mah, I fixed it!)
 egrep -o "(\/(14.3.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.10.3.txt
-## Look for "14.4.0" and output (10.10.4)
 egrep -o "(\/(14.4.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.10.4.txt
-## Look for "14.5.0" and output (10.10.5)
 egrep -o "(\/(14.5.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.10.5.txt
 ### OS X 10.11 El Capitan
-## Look for "15.0.0" and output (10.11.0 and sadly 10.11.1)
-egrep -o "(\/(15.0.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.11.0_1.txt
-## Look for "15.2.0" and output (10.11.2)
+# Cannot distinguish 10.11 from 10.11.1; OS X was not released with Darwin 15.1.
+egrep -o "(\/(15.0.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.11.0.txt
 egrep -o "(\/(15.2.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.11.2.txt
-## Look for "15.3.0" and output (10.11.3)
 egrep -o "(\/(15.3.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.11.3.txt
-## Look for "15.4.0" and output (10.11.4)
 egrep -o "(\/(15.4.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.11.4.txt
-## Look for "15.5.0" and output (10.11.5)
 egrep -o "(\/(15.5.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.11.5.txt
+egrep -o "(\/(15.6.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.11.6.txt
+### OS X 10.12 Sierra
+egrep -o "(\/(16.0.0))" "${tmplocation}"/Total_OS_X.txt > "${tmplocation}"/Total_OS_X_10.12.0.txt
 
 ## Use wc to count the lines from each file to give you a reasonable estimate of total numbers.
 totalosxnumber=`wc -l "${tmplocation}"/Total_OS_X.txt | awk '{print $1}'`
+### OS X 10.5 Leopard
+#total1050number=`wc -l "${tmplocation}"/Total_OS_X_10.5.0.txt | awk '{print $1}'`
+#total1051number=`wc -l "${tmplocation}"/Total_OS_X_10.5.1.txt | awk '{print $1}'`
+#total1052number=`wc -l "${tmplocation}"/Total_OS_X_10.5.2.txt | awk '{print $1}'`
+#total1053number=`wc -l "${tmplocation}"/Total_OS_X_10.5.3.txt | awk '{print $1}'`
+#total1054number=`wc -l "${tmplocation}"/Total_OS_X_10.5.4.txt | awk '{print $1}'`
+#total1055number=`wc -l "${tmplocation}"/Total_OS_X_10.5.5.txt | awk '{print $1}'`
+#total1056number=`wc -l "${tmplocation}"/Total_OS_X_10.5.6.txt | awk '{print $1}'`
+#total1057number=`wc -l "${tmplocation}"/Total_OS_X_10.5.7.txt | awk '{print $1}'`
+#total1058number=`wc -l "${tmplocation}"/Total_OS_X_10.5.8.txt | awk '{print $1}'`
+### OS X 10.6 Snow Leopard
+#total1060number=`wc -l "${tmplocation}"/Total_OS_X_10.6.0.txt | awk '{print $1}'`
+#total1061number=`wc -l "${tmplocation}"/Total_OS_X_10.6.1.txt | awk '{print $1}'`
+#total1062number=`wc -l "${tmplocation}"/Total_OS_X_10.6.2.txt | awk '{print $1}'`
+#total1063number=`wc -l "${tmplocation}"/Total_OS_X_10.6.3.txt | awk '{print $1}'`
+#total1064number=`wc -l "${tmplocation}"/Total_OS_X_10.6.4.txt | awk '{print $1}'`
+#total1065number=`wc -l "${tmplocation}"/Total_OS_X_10.6.5.txt | awk '{print $1}'`
+#total1066number=`wc -l "${tmplocation}"/Total_OS_X_10.6.6.txt | awk '{print $1}'`
+#total1067number=`wc -l "${tmplocation}"/Total_OS_X_10.6.7.txt | awk '{print $1}'`
+#total1068number=`wc -l "${tmplocation}"/Total_OS_X_10.6.8.txt | awk '{print $1}'`
+### OS X 10.7 Lion
+# 10.7.0 remained the same version number with Darwin release 11.0.0 and 11.0.2
+#total1070number=`wc -l "${tmplocation}"/Total_OS_X_10.7.0.txt | awk '{print $1}'`
+#total10701number=`wc -l "${tmplocation}"/Total_OS_X_10.7.0_1.txt | awk '{print $1}'`
+#total1071number=`wc -l "${tmplocation}"/Total_OS_X_10.7.1.txt | awk '{print $1}'`
+#total1072number=`wc -l "${tmplocation}"/Total_OS_X_10.7.2.txt | awk '{print $1}'`
+#total1073number=`wc -l "${tmplocation}"/Total_OS_X_10.7.3.txt | awk '{print $1}'`
+#total1074number=`wc -l "${tmplocation}"/Total_OS_X_10.7.4.txt | awk '{print $1}'`
+#total1075number=`wc -l "${tmplocation}"/Total_OS_X_10.7.5.txt | awk '{print $1}'`
+### OS X 10.8 Mountain Lion
+#total1080number=`wc -l "${tmplocation}"/Total_OS_X_10.8.0.txt | awk '{print $1}'`
+#total1081number=`wc -l "${tmplocation}"/Total_OS_X_10.8.1.txt | awk '{print $1}'`
+total1082number=`wc -l "${tmplocation}"/Total_OS_X_10.8.2.txt | awk '{print $1}'`
+total1083number=`wc -l "${tmplocation}"/Total_OS_X_10.8.3.txt | awk '{print $1}'`
+total1084number=`wc -l "${tmplocation}"/Total_OS_X_10.8.4.txt | awk '{print $1}'`
+total1085number=`wc -l "${tmplocation}"/Total_OS_X_10.8.5.txt | awk '{print $1}'`
+### OS X 10.9 Mavericks
+# Cannot distinguish 10.9.0 from 10.9.1
+total1090number=`wc -l "${tmplocation}"/Total_OS_X_10.9.0.txt | awk '{print $1}'`
+total1091number=`wc -l "${tmplocation}"/Total_OS_X_10.9.1.txt | awk '{print $1}'`
+total1092number=`wc -l "${tmplocation}"/Total_OS_X_10.9.2.txt | awk '{print $1}'`
+total1093number=`wc -l "${tmplocation}"/Total_OS_X_10.9.3.txt | awk '{print $1}'`
+total1094number=`wc -l "${tmplocation}"/Total_OS_X_10.9.4.txt | awk '{print $1}'`
+total1095number=`wc -l "${tmplocation}"/Total_OS_X_10.9.5.txt | awk '{print $1}'`
 ### OS X 10.10 Yosemite
-total10100number=`wc -l "${tmplocation}"/Total_OS_X_10.10.0_1.txt | awk '{print $1}'`
+# Cannot distinguish 10.10.0 from 10.10.1
+total10100number=`wc -l "${tmplocation}"/Total_OS_X_10.10.0.txt | awk '{print $1}'`
 total10102number=`wc -l "${tmplocation}"/Total_OS_X_10.10.2.txt | awk '{print $1}'`
 total10103number=`wc -l "${tmplocation}"/Total_OS_X_10.10.3.txt | awk '{print $1}'`
 total10104number=`wc -l "${tmplocation}"/Total_OS_X_10.10.4.txt | awk '{print $1}'`
 total10105number=`wc -l "${tmplocation}"/Total_OS_X_10.10.5.txt | awk '{print $1}'`
 ### OS X 10.11 El Capitan
-total10110number=`wc -l "${tmplocation}"/Total_OS_X_10.11.0_1.txt | awk '{print $1}'`
+# Cannot distinguish 10.11 from 10.11.1; OS X was not released with Darwin 15.1.
+total10110number=`wc -l "${tmplocation}"/Total_OS_X_10.11.0.txt | awk '{print $1}'`
 total10112number=`wc -l "${tmplocation}"/Total_OS_X_10.11.2.txt | awk '{print $1}'`
 total10113number=`wc -l "${tmplocation}"/Total_OS_X_10.11.3.txt | awk '{print $1}'`
 total10114number=`wc -l "${tmplocation}"/Total_OS_X_10.11.4.txt | awk '{print $1}'`
 total10115number=`wc -l "${tmplocation}"/Total_OS_X_10.11.5.txt | awk '{print $1}'`
+total10116number=`wc -l "${tmplocation}"/Total_OS_X_10.11.6.txt | awk '{print $1}'`
+### OS X 10.12 Sierra
+total10120number=`wc -l "${tmplocation}"/Total_OS_X_10.12.0.txt | awk '{print $1}'`
 
 ## Output Darwin data.
 echo "A total of $totalosxnumber OS X devices hit the Caching Server yesterday consisting of:" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+#echo "  $total1050number OS X Leopard 10.5.0 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+#echo "  $total1051number OS X Leopard 10.5.1 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+#echo "  $total1052number OS X Leopard 10.5.2 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+#echo "  $total1053number OS X Leopard 10.5.3 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+#echo "  $total1054number OS X Leopard 10.5.4 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+#echo "  $total1055number OS X Leopard 10.5.5 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+#echo "  $total1056number OS X Leopard 10.5.6 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+#echo "  $total1057number OS X Leopard 10.5.7 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+#echo "  $total1058number OS X Leopard 10.5.8 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+#echo "  $total1060number OS X Snow Leopard 10.6.0 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+#echo "  $total1061number OS X Snow Leopard 10.6.1 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+#echo "  $total1062number OS X Snow Leopard 10.6.2 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+#echo "  $total1063number OS X Snow Leopard 10.6.3 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+#echo "  $total1064number OS X Snow Leopard 10.6.4 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+#echo "  $total1065number OS X Snow Leopard 10.6.5 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+#echo "  $total1066number OS X Snow Leopard 10.6.6 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+#echo "  $total1067number OS X Snow Leopard 10.6.7 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+#echo "  $total1068number OS X Snow Leopard 10.6.8 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+#echo "  $total1070number OS X Lion 10.7.0 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+#echo "  $total10701number OS X Lion 10.7.0_1 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+#echo "  $total1071number OS X Lion 10.7.1 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+#echo "  $total1072number OS X Lion 10.7.2 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+#echo "  $total1073number OS X Lion 10.7.3 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+#echo "  $total1074number OS X Lion 10.7.4 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+#echo "  $total1075number OS X Lion 10.7.5 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+#echo "  $total1080number OS X Mountain Lion 10.8.0 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+#echo "  $total1081number OS X Mountain Lion 10.8.1 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "  $total1082number OS X Mountain Lion 10.8.2 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "  $total1083number OS X Mountain Lion 10.8.3 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "  $total1084number OS X Mountain Lion 10.8.4 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "  $total1085number OS X Mountain Lion 10.8.5 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "  $total1090number OS X Mavericks 10.9.0/10.9.0.1 Devices [Cannot distinguish between builds]" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "  $total1092number OS X Mavericks 10.9.2 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "  $total1093number OS X Mavericks 10.9.3 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "  $total1094number OS X Mavericks 10.9.4 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "  $total1095number OS X Mavericks 10.9.5 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 echo "  $total10100number OS X Yosemite 10.10.0/10.10.1 Devices [Cannot distinguish between builds]" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 echo "  $total10102number OS X Yosemite 10.10.2 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 echo "  $total10103number OS X Yosemite 10.10.3 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
@@ -634,6 +774,8 @@ echo "  $total10112number OS X El Capitan 10.11.2 Devices" 2>&1 | tee -a "${tmpl
 echo "  $total10113number OS X El Capitan 10.11.3 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 echo "  $total10114number OS X El Capitan 10.11.4 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 echo "  $total10115number OS X El Capitan 10.11.5 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "  $total10116number OS X El Capitan 10.11.6 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "  $total10120number OS X Sierra 10.12.0 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 echo 
 echo  " " 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 

--- a/Cacher
+++ b/Cacher
@@ -3,9 +3,10 @@
 # This script will process Caching Server Debug Logs and e-mail the information to relevant parties
 # through the use of Apple's Server Alert mechanism.
 ## Written by Erik Gomez with help from Google Search.
-## Last Modified 05/16/2016
+## Last Modified 09/23/2016
 
 ## Variables
+version='2.0'
 uptime=`uptime | sed 's/.*up \([^,]*\), .*/\1/'`
 loglocation=/Library/Server/Caching/Logs
 tmplocation=/tmp/CacheLogs
@@ -152,166 +153,121 @@ ibwf=`grep "" "${tmplocation}"/Bandwidth_First.txt | awk '{print $19}'`
 ibwl=`grep "" "${tmplocation}"/Bandwidth_Last.txt | awk '{print $19}'`
 
 #show stats since boot
-echo Uptime: $uptime >> "${tmplocation}"/AlertInfo.txt 
-echo $datasinceboot >> "${tmplocation}"/AlertInfo.txt 
-echo >> "${tmplocation}"/AlertInfo.txt 
+echo "Uptime: $uptime" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "$datasinceboot" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo " " 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 
 # Bandwidth served to clients
-echo "Cacher has retrieved the following stats for $yesterday:"
-echo "Cacher has retrieved the following stats for $yesterday:" >> "${tmplocation}"/AlertInfo.txt 
-echo
-echo  " " >> "${tmplocation}"/AlertInfo.txt 
+echo "Cacher has retrieved the following stats for $yesterday:" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo  " " 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 # Case 1
 if [[ "$cbwf" == "bytes" && "$cbwl" == "bytes" ]]; then
-	echo $case1bwclient Bytes of Bandwidth served to clients.
-	echo "$case1bwclient Bytes of Bandwidth served to clients." >> "${tmplocation}"/AlertInfo.txt
+	echo "$case1bwclient Bytes of Bandwidth served to clients." 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 elif [[ "$cbwf" == "MB" && "$cbwl" == "MB" ]]; then
-	echo $case1bwclient Megabytes of Bandwidth served to clients.
-	echo "$case1bwclient Megabytes of Bandwidth served to clients." >> "${tmplocation}"/AlertInfo.txt
+	echo "$case1bwclient Megabytes of Bandwidth served to clients." 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 elif [[ "$cbwf" == "GB" && "$cbwl" == "GB" ]]; then
-	echo $case1bwclient Gigabytes of Bandwidth served to clients.
-	echo "$case1bwclient Gigabytes of Bandwidth served to clients." >> "${tmplocation}"/AlertInfo.txt
+	echo "$case1bwclient Gigabytes of Bandwidth served to clients." 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 elif [[ "$cbwf" == "TB" && "$cbwl" == "TB" ]]; then
-	echo $case1bwclient Terabytes of Bandwidth served to clients.
-	echo "$case1bwclient Terabytes of Bandwidth served to clients." >> "${tmplocation}"/AlertInfo.txt
+	echo "$case1bwclient Terabytes of Bandwidth served to clients." 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 # Case 2			
 elif [[ "$cbwf" == "bytes" && "$cbwl" == "MB" ]]; then
-	echo $case2bwclient Megabytes of Bandwidth served to clients.
-	echo "$case2bwclient Megabytes of Bandwidth served to clients." >> "${tmplocation}"/AlertInfo.txt
+	echo "$case2bwclient Megabytes of Bandwidth served to clients." 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 elif [[ "$cbwf" == "MB" && "$cbwl" == "GB" ]]; then
-	echo $case2bwclient Gigabytes of Bandwidth served to clients.
-	echo "$case2bwclient Gigabytes of Bandwidth served to clients." >> "${tmplocation}"/AlertInfo.txt
+	echo "$case2bwclient Gigabytes of Bandwidth served to clients." 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 elif [[ "$cbwf" == "GB" && "$cbwl" == "TB" ]]; then
-	echo $case2bwclient Terabytes of Bandwidth served to clients.
-	echo "$case2bwclient Terabytes of Bandwidth served to clients." >> "${tmplocation}"/AlertInfo.txt
+	echo "$case2bwclient Terabytes of Bandwidth served to clients." 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 # Case 3
 elif [[ "$cbwf" == "MB" && "$cbwl" == "bytes" ]]; then
-	echo $case3bwclient Bytes of Bandwidth served to clients.
-	echo "$case3bwclient Bytes of Bandwidth served to clients." >> "${tmplocation}"/AlertInfo.txt
+	echo "$case3bwclient Bytes of Bandwidth served to clients." 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 elif [[ "$cbwf" == "GB" && "$cbwl" == "MB" ]]; then
-	echo $case3bwclient Megabytes of Bandwidth served to clients.
-	echo "$case3bwclient Megabytes of Bandwidth served to clients." >> "${tmplocation}"/AlertInfo.txt
+	echo "$case3bwclient Megabytes of Bandwidth served to clients." 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 elif [[ "$cbwf" == "TB" && "$cbwl" == "GB" ]]; then
-	echo $case3bwclient Gigabytes of Bandwidth served to clients.
-	echo "$case3bwclient Gigabytes of Bandwidth served to clients." >> "${tmplocation}"/AlertInfo.txt
+	echo "$case3bwclient Gigabytes of Bandwidth served to clients." 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 # Case 4
 elif [[ "$cbwf" == "bytes" && "$cbwl" == "GB" ]]; then
-	echo $case4bwclient Gigabytes of Bandwidth served to clients.
-	echo "$case4bwclient Gigabytes of Bandwidth served to clients." >> "${tmplocation}"/AlertInfo.txt
+	echo "$case4bwclient Gigabytes of Bandwidth served to clients." 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 elif [[ "$cbwf" == "MB" && "$cbwl" == "TB" ]]; then
-	echo $case4bwclient Terabytes of Bandwidth served to clients.
-	echo "$case4bwclient Terabytes of Bandwidth served to clients." >> "${tmplocation}"/AlertInfo.txt
+	echo "$case4bwclient Terabytes of Bandwidth served to clients." 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 # Case 5
 elif [[ "$cbwf" == "bytes" && "$cbwl" == "TB" ]]; then
-	echo $case5bwclient Terabytes of Bandwidth served to clients.
-	echo "$case5bwclient Terabytes of Bandwidth served to clients." >> "${tmplocation}"/AlertInfo.txt
+	echo "$case5bwclient Terabytes of Bandwidth served to clients." 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 else
-	echo Cacher could not determine served bandwidth. Please submit a Github issue and privately send your caching logs.
-	echo "Cacher could not determine served bandwidth. Please submit a Github issue and privately send your caching logs." >> "${tmplocation}"/AlertInfo.txt
+	echo "Cacher could not determine served bandwidth. Please submit a Github issue and privately send your caching logs." 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 fi
 
 # Bandwidth requested from Apple
 # Case 1
 if [[ "$rbwf" == "bytes" && "$rbwl" == "bytes" ]]; then
-	echo "  $case1bwapple Bytes of Bandwidth requested from Apple"
-	echo "&nbsp;&nbsp; $case1bwapple Bytes of Bandwidth requested from Apple" >> "${tmplocation}"/AlertInfo.txt
+	echo "    $case1bwapple Bytes of Bandwidth requested from Apple" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 elif [[ "$rbwf" == "MB" && "$rbwl" == "MB" ]]; then
-	echo "  $case1bwapple Megabytes of Bandwidth requested from Apple"
-	echo "&nbsp;&nbsp; $case1bwapple Megabytes of Bandwidth requested from Apple" >> "${tmplocation}"/AlertInfo.txt
+	echo "    $case1bwapple Megabytes of Bandwidth requested from Apple" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 elif [[ "$rbwf" == "GB" && "$rbwl" == "GB" ]]; then
-	echo "  $case1bwapple Gigabytes of Bandwidth requested from Apple"
-	echo "&nbsp;&nbsp; $case1bwapple Gigabytes of Bandwidth requested from Apple" >> "${tmplocation}"/AlertInfo.txt
+	echo "    $case1bwapple Gigabytes of Bandwidth requested from Apple" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 elif [[ "$rbwf" == "TB" && "$rbwl" == "TB" ]]; then
-	echo "  $case1bwapple Terabytes of Bandwidth requested from Apple"
-	echo "&nbsp;&nbsp; $case1bwapple Terabytes of Bandwidth requested from Apple" >> "${tmplocation}"/AlertInfo.txt
+	echo "    $case1bwapple Terabytes of Bandwidth requested from Apple" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 # Case 2			
 elif [[ "$rbwf" == "bytes" && "$rbwl" == "MB" ]]; then
-	echo "  $case2bwapple Megabytes of Bandwidth requested from Apple"
-	echo "&nbsp;&nbsp; $case2bwapple Megabytes of Bandwidth requested from Apple" >> "${tmplocation}"/AlertInfo.txt
+	echo "    $case2bwapple Megabytes of Bandwidth requested from Apple" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 elif [[ "$rbwf" == "MB" && "$rbwl" == "GB" ]]; then
-	echo "  $case2bwapple Gigabytes of Bandwidth requested from Apple"
-	echo "&nbsp;&nbsp; $case2bwapple Gigabytes of Bandwidth requested from Apple" >> "${tmplocation}"/AlertInfo.txt
+	echo "    $case2bwapple Gigabytes of Bandwidth requested from Apple" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 elif [[ "$rbwf" == "GB" && "$rbwl" == "TB" ]]; then
-	echo "  $case2bwapple Terabytes of Bandwidth requested from Apple"
-	echo "&nbsp;&nbsp; $case2bwapple Terabytes of Bandwidth requested from Apple" >> "${tmplocation}"/AlertInfo.txt
+	echo "    $case2bwapple Terabytes of Bandwidth requested from Apple" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 # Case 3
 elif [[ "$rbwf" == "MB" && "$rbwl" == "bytes" ]]; then
-	echo "  $case3bwapple Bytes of Bandwidth requested from Apple"
-	echo "&nbsp;&nbsp; $case3bwapple Bytes of Bandwidth requested from Apple" >> "${tmplocation}"/AlertInfo.txt
+	echo "    $case3bwapple Bytes of Bandwidth requested from Apple" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 elif [[ "$rbwf" == "GB" && "$rbwl" == "MB" ]]; then
-	echo "  $case3bwapple Megabytes of Bandwidth requested from Apple"
-	echo "&nbsp;&nbsp; $case3bwapple Megabytes of Bandwidth requested from Apple" >> "${tmplocation}"/AlertInfo.txt
+	echo "    $case3bwapple Megabytes of Bandwidth requested from Apple" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 elif [[ "$rbwf" == "TB" && "$rbwl" == "GB" ]]; then
-	echo "  $case3bwapple Gigabytes of Bandwidth requested from Apple"
-	echo "&nbsp;&nbsp; $case3bwapple Gigabytes of Bandwidth requested from Apple" >> "${tmplocation}"/AlertInfo.txt
+	echo "    $case3bwapple Gigabytes of Bandwidth requested from Apple" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 # Case 4
 elif [[ "$rbwf" == "bytes" && "$rbwl" == "GB" ]]; then
-	echo "  $case4bwapple Gigabytes of Bandwidth requested from Apple"
-	echo "&nbsp;&nbsp; $case4bwapple Gigabytes of Bandwidth requested from Apple" >> "${tmplocation}"/AlertInfo.txt
+	echo "    $case4bwapple Gigabytes of Bandwidth requested from Apple" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 elif [[ "$rbwf" == "MB" && "$rbwl" == "TB" ]]; then
-	echo "  $case4bwapple Terabytes of Bandwidth requested from Apple"
-	echo "&nbsp;&nbsp; $case4bwapple Terabytes of Bandwidth requested from Apple" >> "${tmplocation}"/AlertInfo.txt
+	echo "    $case4bwapple Terabytes of Bandwidth requested from Apple" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 # Case 5
 elif [[ "$rbwf" == "bytes" && "$rbwl" == "TB" ]]; then
-	echo "  $case5bwapple Terabytes of Bandwidth requested from Apple:"
-	echo "&nbsp;&nbsp; $case5bwapple Terabytes of Bandwidth requested from Apple" >> "${tmplocation}"/AlertInfo.txt
+	echo "    $case5bwapple Terabytes of Bandwidth requested from Apple:" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 else
-	echo "  Cacher could not determine requested bandwith. Please submit a Github issue and privately send your caching logs."
-	echo "&nbsp;&nbsp; Cacher could not determine requested bandwith. Please submit a Github issue and privately send your caching logs." >> "${tmplocation}"/AlertInfo.txt
+	echo "    Cacher could not determine requested bandwith. Please submit a Github issue and privately send your caching logs." 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 fi
 
 # Bandwidth requested from other Caching Servers
 # Case 1
 if [[ "$pbwf" == "bytes" && "$pbwl" == "bytes" ]]; then
-	echo "    $case1bwpeer Bytes of Bandwidth requested from other Caching Servers"
-	echo "&nbsp;&nbsp;&nbsp;&nbsp; $case1bwpeer Bytes of Bandwidth requested from other Caching Servers" >> "${tmplocation}"/AlertInfo.txt
+	echo "    $case1bwpeer Bytes of Bandwidth requested from other Caching Servers" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 elif [[ "$pbwf" == "MB" && "$pbwl" == "MB" ]]; then
-	echo "    $case1bwpeer Megabytes of Bandwidth requested from other Caching Servers"
-	echo "&nbsp;&nbsp;&nbsp;&nbsp; $case1bwpeer Megabytes of Bandwidth requested from other Caching Servers" >> "${tmplocation}"/AlertInfo.txt
+	echo "    $case1bwpeer Megabytes of Bandwidth requested from other Caching Servers" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 elif [[ "$pbwf" == "GB" && "$pbwl" == "GB" ]]; then
-	echo "    $case1bwpeer Gigabytes of Bandwidth requested from other Caching Servers"
-	echo "&nbsp;&nbsp;&nbsp;&nbsp; $case1bwpeer Gigabytes of Bandwidth requested from other Caching Servers" >> "${tmplocation}"/AlertInfo.txt
+	echo "    $case1bwpeer Gigabytes of Bandwidth requested from other Caching Servers" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 elif [[ "$pbwf" == "TB" && "$pbwl" == "TB" ]]; then
-	echo "    $case1bwpeer Terabytes of Bandwidth requested from other Caching Servers"
-	echo "&nbsp;&nbsp;&nbsp;&nbsp; $case1bwpeer Terabytes of Bandwidth requested from other Caching Servers" >> "${tmplocation}"/AlertInfo.txt
+	echo "    $case1bwpeer Terabytes of Bandwidth requested from other Caching Servers" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 # Case 2			
 elif [[ "$pbwf" == "bytes" && "$pbwl" == "MB" ]]; then
-	echo "    $case2bwpeer Megabytes of Bandwidth requested from other Caching Servers"
-	echo "&nbsp;&nbsp;&nbsp;&nbsp; $case2bwpeer Megabytes of Bandwidth requested from other Caching Servers" >> "${tmplocation}"/AlertInfo.txt
+	echo "    $case2bwpeer Megabytes of Bandwidth requested from other Caching Servers" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 elif [[ "$pbwf" == "MB" && "$pbwl" == "GB" ]]; then
-	echo "    $case2bwpeer Gigabytes of Bandwidth requested from other Caching Servers"
-	echo "&nbsp;&nbsp;&nbsp;&nbsp; $case2bwpeer Gigabytes of Bandwidth requested from other Caching Servers" >> "${tmplocation}"/AlertInfo.txt
+	echo "    $case2bwpeer Gigabytes of Bandwidth requested from other Caching Servers" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 elif [[ "$pbwf" == "GB" && "$pbwl" == "TB" ]]; then
-	echo "    $case2bwpeer Terabytes of Bandwidth requested from other Caching Servers"
-	echo "&nbsp;&nbsp;&nbsp;&nbsp; $case2bwpeer Terabytes of Bandwidth requested from other Caching Servers" >> "${tmplocation}"/AlertInfo.txt
+	echo "    $case2bwpeer Terabytes of Bandwidth requested from other Caching Servers" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 # Case 3
 elif [[ "$pbwf" == "MB" && "$pbwl" == "bytes" ]]; then
-	echo "    $case3bwpeer Bytes of Bandwidth requested from other Caching Servers"
-	echo "&nbsp;&nbsp;&nbsp;&nbsp; $case3bwpeer Bytes of Bandwidth requested from other Caching Servers" >> "${tmplocation}"/AlertInfo.txt
+	echo "    $case3bwpeer Bytes of Bandwidth requested from other Caching Servers" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 elif [[ "$pbwf" == "GB" && "$pbwl" == "MB" ]]; then
-	echo "    $case3bwpeer Megabytes of Bandwidth requested from other Caching Servers"
-	echo "&nbsp;&nbsp;&nbsp;&nbsp; $case3bwpeer Megabytes of Bandwidth requested from other Caching Servers" >> "${tmplocation}"/AlertInfo.txt
+	echo "    $case3bwpeer Megabytes of Bandwidth requested from other Caching Servers" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 elif [[ "$pbwf" == "TB" && "$pbwl" == "GB" ]]; then
-	echo "    $case3bwpeer Gigabytes of Bandwidth requested from other Caching Servers"
-	echo "&nbsp;&nbsp;&nbsp;&nbsp; $case3bwpeer Gigabytes of Bandwidth requested from other Caching Servers" >> "${tmplocation}"/AlertInfo.txt
+	echo "    $case3bwpeer Gigabytes of Bandwidth requested from other Caching Servers" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 # Case 4
 elif [[ "$pbwf" == "bytes" && "$pbwl" == "GB" ]]; then
-	echo "    $case4bwpeer Gigabytes of Bandwidth requested from other Caching Servers"
-	echo "&nbsp;&nbsp;&nbsp;&nbsp; $case4bwpeer Gigabytes of Bandwidth requested from other Caching Servers" >> "${tmplocation}"/AlertInfo.txt
+	echo "    $case4bwpeer Gigabytes of Bandwidth requested from other Caching Servers" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 elif [[ "$pbwf" == "MB" && "$pbwl" == "TB" ]]; then
-	echo "    $case4bwpeer Terabytes of Bandwidth requested from other Caching Servers"
-	echo "&nbsp;&nbsp;&nbsp;&nbsp; $case4bwpeer Terabytes of Bandwidth requested from other Caching Servers" >> "${tmplocation}"/AlertInfo.txt
+	echo "    $case4bwpeer Terabytes of Bandwidth requested from other Caching Servers" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 # Case 5
 elif [[ "$pbwf" == "bytes" && "$pbwl" == "TB" ]]; then
-	echo "    $case5bwpeer Terabytes of Bandwidth requested from other Caching Servers"
-	echo "&nbsp;&nbsp;&nbsp;&nbsp; $case5bwpeer Terabytes of Bandwidth requested from other Caching Servers" >> "${tmplocation}"/AlertInfo.txt
+	echo "    $case5bwpeer Terabytes of Bandwidth requested from other Caching Servers" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 else
-	echo "    Cacher could not determine bandwidth from other Caching Servers. Please submit a Github issue and privately send your caching logs."
-	echo "&nbsp;&nbsp;&nbsp;&nbsp; Cacher could not determine bandwidth from other Caching Servers. Please submit a Github issue and privately send your caching logs." >> "${tmplocation}"/AlertInfo.txt
+	echo "    Cacher could not determine bandwidth from other Caching Servers. Please submit a Github issue and privately send your caching logs." 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 fi
 
-echo
-echo  " " >> "${tmplocation}"/AlertInfo.txt
+echo  " " 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 
 # Stage III: Extract IP's from log file, output into file and remove duplicates.
 
@@ -327,12 +283,9 @@ totalipnumber=`wc -l "${tmplocation}"/Total_IPs.txt | awk '{print $1}'`
 uniqueipnumber=`wc -l "${tmplocation}"/Unique_IPs.txt | awk '{print $1}'`
 
 ## Output data.
-echo $totalipnumber IP Addresses hit the Caching Server yesterday consisting of:
-echo "$totalipnumber IP Addresses hit the Caching Server yesterday consisting of:" >> "${tmplocation}"/AlertInfo.txt
-echo "  $uniqueipnumber Unique IP Addresses."
-echo "&nbsp;&nbsp; $uniqueipnumber Unique IP Addresses." >> "${tmplocation}"/AlertInfo.txt
-echo
-echo  " " >> "${tmplocation}"/AlertInfo.txt
+echo "$totalipnumber IP Addresses hit the Caching Server yesterday consisting of:" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "  $uniqueipnumber Unique IP Addresses." 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo  " " 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 
 
 # Stage IV: Extract iOS Models and build number count.
@@ -541,165 +494,90 @@ totalipod71=`egrep -o "(iPod7,1)" "${tmplocation}"/Total_models.txt | wc -l | aw
 
 ## Output data.
 ## Total iOS device numbers
-echo A total of $totaliosnumber iOS devices hit the Caching Server yesterday consisting of:
-echo "A total of $totaliosnumber iOS devices hit the Caching Server yesterday consisting of:" >> "${tmplocation}"/AlertInfo.txt
-echo "  $totalios800number iOS 8.0 Devices"
-echo "&nbsp;&nbsp; $totalios800number iOS 8.0 Devices" >> "${tmplocation}"/AlertInfo.txt
-echo "  $totalios802number iOS 8.0.2 Devices"
-echo "&nbsp;&nbsp; $totalios802number iOS 8.0.2 Devices" >> "${tmplocation}"/AlertInfo.txt
-echo "  $totalios810number iOS 8.1 Devices"
-echo "&nbsp;&nbsp; $totalios810number iOS 8.1 Devices" >> "${tmplocation}"/AlertInfo.txt
-echo "  $totalios811number iOS 8.1.1 Devices"
-echo "&nbsp;&nbsp; $totalios811number iOS 8.1.1 Devices" >> "${tmplocation}"/AlertInfo.txt
-echo "  $totalios812number iOS 8.1.2 Devices"
-echo "&nbsp;&nbsp; $totalios812number iOS 8.1.2 Devices" >> "${tmplocation}"/AlertInfo.txt
-echo "  $totalios813number iOS 8.1.3 Devices"
-echo "&nbsp;&nbsp; $totalios813number iOS 8.1.3 Devices" >> "${tmplocation}"/AlertInfo.txt
-echo "  $totalios820number iOS 8.2 Devices"
-echo "&nbsp;&nbsp; $totalios820number iOS 8.2 Devices" >> "${tmplocation}"/AlertInfo.txt
-echo "  $totalios830number iOS 8.3 Devices"
-echo "&nbsp;&nbsp; $totalios830number iOS 8.3 Devices" >> "${tmplocation}"/AlertInfo.txt
-echo "  $totalios840number iOS 8.4 Devices"
-echo "&nbsp;&nbsp; $totalios840number iOS 8.4 Devices" >> "${tmplocation}"/AlertInfo.txt
-echo "  $totalios841number iOS 8.4.1 Devices"
-echo "&nbsp;&nbsp; $totalios841number iOS 8.4.1 Devices" >> "${tmplocation}"/AlertInfo.txt
-echo "  $totalios900number iOS 9.0 Devices"
-echo "&nbsp;&nbsp; $totalios900number iOS 9.0 Devices" >> "${tmplocation}"/AlertInfo.txt
-echo "  $totalios901number iOS 9.0.1 Devices"
-echo "&nbsp;&nbsp; $totalios901number iOS 9.0.1 Devices" >> "${tmplocation}"/AlertInfo.txt
-echo "  $totalios902number iOS 9.0.2 Devices"
-echo "&nbsp;&nbsp; $totalios902number iOS 9.0.2 Devices" >> "${tmplocation}"/AlertInfo.txt
-echo "  $totalios910number iOS 9.1 Devices"
-echo "&nbsp;&nbsp; $totalios910number iOS 9.1 Devices" >> "${tmplocation}"/AlertInfo.txt
-echo "  $totalios920number iOS 9.2 Devices"
-echo "&nbsp;&nbsp; $totalios920number iOS 9.2 Devices" >> "${tmplocation}"/AlertInfo.txt
-echo "  $totalios921number iOS 9.2.1 Devices"
-echo "&nbsp;&nbsp; $totalios921number iOS 9.2.1 Devices" >> "${tmplocation}"/AlertInfo.txt
-echo "  $totalios930number iOS 9.3 Devices"
-echo "&nbsp;&nbsp; $totalios930number iOS 9.3 Devices" >> "${tmplocation}"/AlertInfo.txt
-echo "  $totalios931number iOS 9.3.1 Devices"
-echo "&nbsp;&nbsp; $totalios931number iOS 9.3.1 Devices" >> "${tmplocation}"/AlertInfo.txt
-echo "  $totalios932number iOS 9.3.2 Devices"
-echo "&nbsp;&nbsp; $totalios932number iOS 9.3.2 Devices" >> "${tmplocation}"/AlertInfo.txt
-echo "  $totalios1001number iOS 10.0.1 Devices"
-echo "&nbsp;&nbsp; $totalios1001number iOS 10.0.1 Devices" >> "${tmplocation}"/AlertInfo.txt
+echo "A total of $totaliosnumber iOS devices hit the Caching Server yesterday consisting of:" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "  $totalios800number iOS 8.0 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "  $totalios802number iOS 8.0.2 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "  $totalios810number iOS 8.1 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "  $totalios811number iOS 8.1.1 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "  $totalios812number iOS 8.1.2 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "  $totalios813number iOS 8.1.3 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "  $totalios820number iOS 8.2 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "  $totalios830number iOS 8.3 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "  $totalios840number iOS 8.4 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "  $totalios841number iOS 8.4.1 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "  $totalios900number iOS 9.0 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "  $totalios901number iOS 9.0.1 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "  $totalios902number iOS 9.0.2 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "  $totalios910number iOS 9.1 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "  $totalios920number iOS 9.2 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "  $totalios921number iOS 9.2.1 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "  $totalios930number iOS 9.3 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "  $totalios931number iOS 9.3.1 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "  $totalios932number iOS 9.3.2 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "  $totalios1001number iOS 10.0.1 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 echo 
-echo  " " >> "${tmplocation}"/AlertInfo.txt
+echo  " " 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 ## iOS Model Breakdown
-echo Of these devices, here is the model breakdown:
-echo "Of these devices, here is the model breakdown:" >> "${tmplocation}"/AlertInfo.txt
+echo "Of these devices, here is the model breakdown:" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 ### Apple TVs
-echo "  $totalappletvnumber Total AppleTVs"
-echo "&nbsp;&nbsp; $totalappletvnumber Total AppleTVs" >> "${tmplocation}"/AlertInfo.txt
-echo "    $totalappletv31 3rd Generation Apple TVs"
-echo "&nbsp;&nbsp;&nbsp;&nbsp; $totalappletv31 3rd Generation Apple TVs" >> "${tmplocation}"/AlertInfo.txt
-echo "    $totalappletv32 4th Generation Apple TVs"
-echo "&nbsp;&nbsp;&nbsp;&nbsp; $totalappletv32 4th Generation Apple TVs" >> "${tmplocation}"/AlertInfo.txt
-echo "    $totalappletv53 5th Generation Apple TVs"
-echo "&nbsp;&nbsp;&nbsp;&nbsp; $totalappletv53 5th Generation Apple TVs" >> "${tmplocation}"/AlertInfo.txt
+echo "  $totalappletvnumber Total AppleTVs" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "    $totalappletv31 3rd Generation Apple TVs" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "    $totalappletv32 4th Generation Apple TVs" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "    $totalappletv53 5th Generation Apple TVs" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 ### iPhones
-echo "  $totaliphonenumber Total iPhones"
-echo "&nbsp;&nbsp; $totaliphonenumber Total iPhones" >> "${tmplocation}"/AlertInfo.txt
-echo "    $totaliphone31 iPhone 4 [GSM]"
-echo "&nbsp;&nbsp;&nbsp;&nbsp; $totaliphone31 iPhone 4 [GSM]" >> "${tmplocation}"/AlertInfo.txt
-echo "    $totaliphone32 iPhone 4 [GSM 2012]"
-echo "&nbsp;&nbsp;&nbsp;&nbsp; $totaliphone32 iPhone 4 [GSM 2012]" >> "${tmplocation}"/AlertInfo.txt
-echo "    $totaliphone33 iPhone 4 [CDMA]"
-echo "&nbsp;&nbsp;&nbsp;&nbsp; $totaliphone33 iPhone 4 [CDMA]" >> "${tmplocation}"/AlertInfo.txt
-echo "    $totaliphone41 iPhone 4S"
-echo "&nbsp;&nbsp;&nbsp;&nbsp; $totaliphone41 iPhone 4S" >> "${tmplocation}"/AlertInfo.txt
-echo "    $totaliphone51 iPhone 5 [GSM]"
-echo "&nbsp;&nbsp;&nbsp;&nbsp; $totaliphone51 iPhone 5 [GSM]" >> "${tmplocation}"/AlertInfo.txt
-echo "    $totaliphone52 iPhone 5 [CDMA]"
-echo "&nbsp;&nbsp;&nbsp;&nbsp; $totaliphone52 iPhone 5 [CDMA]" >> "${tmplocation}"/AlertInfo.txt
-echo "    $totaliphone53 iPhone 5C"
-echo "&nbsp;&nbsp;&nbsp;&nbsp; $totaliphone53 iPhone 5C" >> "${tmplocation}"/AlertInfo.txt
-echo "    $totaliphone54 iPhone 5C [Global]"
-echo "&nbsp;&nbsp;&nbsp;&nbsp; $totaliphone54 iPhone 5C [Global]" >> "${tmplocation}"/AlertInfo.txt
-echo "    $totaliphone61 iPhone 5S"
-echo "&nbsp;&nbsp;&nbsp;&nbsp; $totaliphone61 iPhone 5S" >> "${tmplocation}"/AlertInfo.txt
-echo "    $totaliphone62 iPhone 5S [China Model]"
-echo "&nbsp;&nbsp;&nbsp;&nbsp; $totaliphone62 iPhone 5S [China Model]" >> "${tmplocation}"/AlertInfo.txt
-echo "    $totaliphone72 iPhone 6"
-echo "&nbsp;&nbsp;&nbsp;&nbsp; $totaliphone72 iPhone 6" >> "${tmplocation}"/AlertInfo.txt
-echo "    $totaliphone71 iPhone 6 Plus"
-echo "&nbsp;&nbsp;&nbsp;&nbsp; $totaliphone71 iPhone 6 Plus" >> "${tmplocation}"/AlertInfo.txt
-echo "    $totaliphone81 iPhone 6S"
-echo "&nbsp;&nbsp;&nbsp;&nbsp; $totaliphone81 iPhone 6S" >> "${tmplocation}"/AlertInfo.txt
-echo "    $totaliphone82 iPhone 6S Plus"
-echo "&nbsp;&nbsp;&nbsp;&nbsp; $totaliphone82 iPhone 6S Plus" >> "${tmplocation}"/AlertInfo.txt
-echo "    $totaliphone84 iPhone SE"
-echo "&nbsp;&nbsp;&nbsp;&nbsp; $totaliphone84 iPhone SE" >> "${tmplocation}"/AlertInfo.txt
+echo "  $totaliphonenumber Total iPhones" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "    $totaliphone31 iPhone 4 [GSM]" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "    $totaliphone32 iPhone 4 [GSM 2012]" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "    $totaliphone33 iPhone 4 [CDMA]" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "    $totaliphone41 iPhone 4S" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "    $totaliphone51 iPhone 5 [GSM]" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "    $totaliphone52 iPhone 5 [CDMA]" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "    $totaliphone53 iPhone 5C" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "    $totaliphone54 iPhone 5C [Global]" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "    $totaliphone61 iPhone 5S" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "    $totaliphone62 iPhone 5S [China Model]" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "    $totaliphone72 iPhone 6" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "    $totaliphone71 iPhone 6 Plus" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "    $totaliphone81 iPhone 6S" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "    $totaliphone82 iPhone 6S Plus" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "    $totaliphone84 iPhone SE" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 ### iPads
-echo "  $totalipadnumber Total iPads"
-echo "&nbsp;&nbsp; $totalipadnumber Total iPads" >> "${tmplocation}"/AlertInfo.txt
-echo "    $totalipad21 iPad 2nd Generation [Wifi]"
-echo "&nbsp;&nbsp;&nbsp;&nbsp; $totalipad21 iPad 2nd Generation [Wifi]" >> "${tmplocation}"/AlertInfo.txt
-echo "    $totalipad22 iPad 2nd Generation [Wifi + GSM]"
-echo "&nbsp;&nbsp;&nbsp;&nbsp; $totalipad22 iPad 2nd Generation [Wifi + GSM]" >> "${tmplocation}"/AlertInfo.txt
-echo "    $totalipad23 iPad 2nd Generation [Wifi + CDMA]"
-echo "&nbsp;&nbsp;&nbsp;&nbsp; $totalipad23 iPad 2nd Generation [Wifi + CDMA]" >> "${tmplocation}"/AlertInfo.txt
-echo "    $totalipad24 iPad 2nd Generation [M2012 Wifi Revision]"
-echo "&nbsp;&nbsp;&nbsp;&nbsp; $totalipad24 iPad 2nd Generation [M2012 Wifi Revision]" >> "${tmplocation}"/AlertInfo.txt
-echo "    $totalipad31 iPad 3rd Generation [Wifi]"
-echo "&nbsp;&nbsp;&nbsp;&nbsp; $totalipad31 iPad 3rd Generation [Wifi]" >> "${tmplocation}"/AlertInfo.txt
-echo "    $totalipad32 iPad 3rd Generation [Wifi + GSM]"
-echo "&nbsp;&nbsp;&nbsp;&nbsp; $totalipad32 iPad 3rd Generation [Wifi + GSM]" >> "${tmplocation}"/AlertInfo.txt
-echo "    $totalipad33 iPad 3rd Generation [Wifi + CDMA]"
-echo "&nbsp;&nbsp;&nbsp;&nbsp; $totalipad33 iPad 3rd Generation [Wifi + CDMA]" >> "${tmplocation}"/AlertInfo.txt
-echo "    $totalipad34 iPad 4th Generation [Wifi]"
-echo "&nbsp;&nbsp;&nbsp;&nbsp; $totalipad34 iPad 4th Generation [Wifi]" >> "${tmplocation}"/AlertInfo.txt
-echo "    $totalipad35 iPad 4th Generation [Wifi + GSM]"
-echo "&nbsp;&nbsp;&nbsp;&nbsp; $totalipad35 iPad 4th Generation [Wifi + GSM]" >> "${tmplocation}"/AlertInfo.txt
-echo "    $totalipad36 iPad 4th Generation [Wifi + CDMA]"
-echo "&nbsp;&nbsp;&nbsp;&nbsp; $totalipad36 iPad 4th Generation [Wifi + CDMA]" >> "${tmplocation}"/AlertInfo.txt
-echo "    $totalipad41 iPad Air 1st Generation [Wifi]"
-echo "&nbsp;&nbsp;&nbsp;&nbsp; $totalipad41 iPad Air 1st Generation [Wifi]" >> "${tmplocation}"/AlertInfo.txt
-echo "    $totalipad42 iPad Air 1st Generation [Wifi + Cellular]"
-echo "&nbsp;&nbsp;&nbsp;&nbsp; $totalipad42 iPad Air 1st Generation [Wifi + Cellular]" >> "${tmplocation}"/AlertInfo.txt
-echo "    $totalipad43 iPad Air 1st Generation [China Model]"
-echo "&nbsp;&nbsp;&nbsp;&nbsp; $totalipad43 iPad Air 1st Generation [China Model]" >> "${tmplocation}"/AlertInfo.txt
-echo "    $totalipad53 iPad Air 2nd Generation [Wifi]"
-echo "&nbsp;&nbsp;&nbsp;&nbsp; $totalipad53 iPad Air 2nd Generation [Wifi]" >> "${tmplocation}"/AlertInfo.txt
-echo "    $totalipad54 iPad Air 2nd Generation [Wifi + Cellular]"
-echo "&nbsp;&nbsp;&nbsp;&nbsp; $totalipad54 iPad Air 2nd Generation [Wifi + Cellular]" >> "${tmplocation}"/AlertInfo.txt
-echo "    $totalipad25 iPad Mini 1st Generation [Wifi]"
-echo "&nbsp;&nbsp;&nbsp;&nbsp; $totalipad25 iPad Mini 1st Generation [Wifi]" >> "${tmplocation}"/AlertInfo.txt
-echo "    $totalipad26 iPad Mini 1st Generation [Wifi + GSM]"
-echo "&nbsp;&nbsp;&nbsp;&nbsp; $totalipad26 iPad Mini 1st Generation [Wifi + GSM]" >> "${tmplocation}"/AlertInfo.txt
-echo "    $totalipad27 iPad Mini 1st Generation [Wifi + CDMA]"
-echo "&nbsp;&nbsp;&nbsp;&nbsp; $totalipad27 iPad Mini 1st Generation [Wifi + CDMA]" >> "${tmplocation}"/AlertInfo.txt
-echo "    $totalipad44 iPad Mini 2nd Generation [Wifi]"
-echo "&nbsp;&nbsp;&nbsp;&nbsp; $totalipad44 iPad Mini 2nd Generation [Wifi]" >> "${tmplocation}"/AlertInfo.txt
-echo "    $totalipad45 iPad Mini 2nd Generation [Wifi + Cellular]"
-echo "&nbsp;&nbsp;&nbsp;&nbsp; $totalipad45 iPad Mini 2nd Generation [Wifi + Cellular]" >> "${tmplocation}"/AlertInfo.txt
-echo "    $totalipad47 iPad Mini 3rd Generation [Wifi]"
-echo "&nbsp;&nbsp;&nbsp;&nbsp; $totalipad47 iPad Mini 3rd Generation [Wifi]" >> "${tmplocation}"/AlertInfo.txt
-echo "    $totalipad48 iPad Mini 3rd Generation [Wifi + Cellular]"
-echo "&nbsp;&nbsp;&nbsp;&nbsp; $totalipad48 iPad Mini 3rd Generation [Wifi + Cellular]" >> "${tmplocation}"/AlertInfo.txt
-echo "    $totalipad49 iPad Mini 3rd Generation [China Model]"
-echo "&nbsp;&nbsp;&nbsp;&nbsp; $totalipad49 iPad Mini 3rd Generation [China Model]" >> "${tmplocation}"/AlertInfo.txt
-echo "    $totalipad51 iPad Mini 4th Generation [Wifi]"
-echo "&nbsp;&nbsp;&nbsp;&nbsp; $totalipad51 iPad Mini 4th Generation [Wifi]" >> "${tmplocation}"/AlertInfo.txt
-echo "    $totalipad52 iPad Mini 4th Generation [Wifi + Cellular]"
-echo "&nbsp;&nbsp;&nbsp;&nbsp; $totalipad52 iPad Mini 4th Generation [Wifi + Cellular]" >> "${tmplocation}"/AlertInfo.txt
-echo "    $totalipad63 iPad Pro 9.7 Inch 1st Generation [Wifi]"
-echo "&nbsp;&nbsp;&nbsp;&nbsp; $totalipad63 iPad Pro 9.7 Inch 1st Generation [Wifi]" >> "${tmplocation}"/AlertInfo.txt
-echo "    $totalipad64 iPad Pro 9.7 Inch 1st Generation [Wifi + Cellular]"
-echo "&nbsp;&nbsp;&nbsp;&nbsp; $totalipad64 iPad Pro 9.7 Inch 1st Generation [Wifi + Cellular]" >> "${tmplocation}"/AlertInfo.txt
-echo "    $totalipad67 iPad Pro 12.9 Inch 1st Generation [Wifi]"
-echo "&nbsp;&nbsp;&nbsp;&nbsp; $totalipad67 iPad Pro 12.9 Inch 1st Generation [Wifi]" >> "${tmplocation}"/AlertInfo.txt
-echo "    $totalipad68 iPad Pro 12.9 Inch 1st Generation [Wifi + Cellular]"
-echo "&nbsp;&nbsp;&nbsp;&nbsp; $totalipad68 iPad Pro 12.9 Inch 1st Generation [Wifi + Cellular]" >> "${tmplocation}"/AlertInfo.txt
+echo "  $totalipadnumber Total iPads" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "    $totalipad21 iPad 2nd Generation [Wifi]" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "    $totalipad22 iPad 2nd Generation [Wifi + GSM]" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "    $totalipad23 iPad 2nd Generation [Wifi + CDMA]" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "    $totalipad24 iPad 2nd Generation [M2012 Wifi Revision]" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "    $totalipad31 iPad 3rd Generation [Wifi]" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "    $totalipad32 iPad 3rd Generation [Wifi + GSM]" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "    $totalipad33 iPad 3rd Generation [Wifi + CDMA]" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "    $totalipad34 iPad 4th Generation [Wifi]" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "    $totalipad35 iPad 4th Generation [Wifi + GSM]" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "    $totalipad36 iPad 4th Generation [Wifi + CDMA]" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "    $totalipad41 iPad Air 1st Generation [Wifi]" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "    $totalipad42 iPad Air 1st Generation [Wifi + Cellular]" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "    $totalipad43 iPad Air 1st Generation [China Model]" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "    $totalipad53 iPad Air 2nd Generation [Wifi]" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "    $totalipad54 iPad Air 2nd Generation [Wifi + Cellular]" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "    $totalipad25 iPad Mini 1st Generation [Wifi]" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "    $totalipad26 iPad Mini 1st Generation [Wifi + GSM]" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "    $totalipad27 iPad Mini 1st Generation [Wifi + CDMA]" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "    $totalipad44 iPad Mini 2nd Generation [Wifi]" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "    $totalipad45 iPad Mini 2nd Generation [Wifi + Cellular]" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "    $totalipad47 iPad Mini 3rd Generation [Wifi]" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "    $totalipad48 iPad Mini 3rd Generation [Wifi + Cellular]" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "    $totalipad49 iPad Mini 3rd Generation [China Model]" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "    $totalipad51 iPad Mini 4th Generation [Wifi]" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "    $totalipad52 iPad Mini 4th Generation [Wifi + Cellular]" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "    $totalipad63 iPad Pro 9.7 Inch 1st Generation [Wifi]" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "    $totalipad64 iPad Pro 9.7 Inch 1st Generation [Wifi + Cellular]" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "    $totalipad67 iPad Pro 12.9 Inch 1st Generation [Wifi]" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "    $totalipad68 iPad Pro 12.9 Inch 1st Generation [Wifi + Cellular]" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 ### iPods
-echo "  $totalipodnumber Total iPods"
-echo "&nbsp;&nbsp; $totalipodnumber Total iPods" >> "${tmplocation}"/AlertInfo.txt
-echo "    $totalipod51 iPod Touch 5th Generation"
-echo "&nbsp;&nbsp;&nbsp;&nbsp; $totalipod51 iPod Touch 5th Generation" >> "${tmplocation}"/AlertInfo.txt
-echo "    $totalipod71 iPod Touch 6th Generation"
-echo "&nbsp;&nbsp;&nbsp;&nbsp; $totalipod71 iPod Touch 6th Generation" >> "${tmplocation}"/AlertInfo.txt
+echo "  $totalipodnumber Total iPods" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "    $totalipod51 iPod Touch 5th Generation" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "    $totalipod71 iPod Touch 6th Generation" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 echo 
-echo  " " >> "${tmplocation}"/AlertInfo.txt
+echo  " " 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 
 # Stage V: Extract OS X build number count.
 
@@ -745,30 +623,19 @@ total10114number=`wc -l "${tmplocation}"/Total_OS_X_10.11.4.txt | awk '{print $1
 total10115number=`wc -l "${tmplocation}"/Total_OS_X_10.11.5.txt | awk '{print $1}'`
 
 ## Output Darwin data.
-echo A total of $totalosxnumber OS X devices hit the Caching Server yesterday consisting of:
-echo "A total of $totalosxnumber OS X devices hit the Caching Server yesterday consisting of:" >> "${tmplocation}"/AlertInfo.txt
-echo "  $total10100number OS X Yosemite 10.10.0/10.10.1 Devices [Cannot distinguish between builds]"
-echo "&nbsp;&nbsp; $total10100number OS X Yosemite 10.10.0/10.10.1 Devices [Cannot distinguish between builds]" >> "${tmplocation}"/AlertInfo.txt
-echo "  $total10102number OS X Yosemite 10.10.2 Devices"
-echo "&nbsp;&nbsp; $total10102number OS X Yosemite 10.10.2 Devices" >> "${tmplocation}"/AlertInfo.txt
-echo "  $total10103number OS X Yosemite 10.10.3 Devices"
-echo "&nbsp;&nbsp; $total10103number OS X Yosemite 10.10.3 Devices" >> "${tmplocation}"/AlertInfo.txt
-echo "  $total10104number OS X Yosemite 10.10.4 Devices"
-echo "&nbsp;&nbsp; $total10104number OS X Yosemite 10.10.4 Devices" >> "${tmplocation}"/AlertInfo.txt
-echo "  $total10105number OS X Yosemite 10.10.5 Devices"
-echo "&nbsp;&nbsp; $total10105number OS X Yosemite 10.10.5 Devices" >> "${tmplocation}"/AlertInfo.txt
-echo "  $total10110number OS X El Capitan 10.11.0/10.11.1 Devices [Cannot distinguish between builds]"
-echo "&nbsp;&nbsp; $total10110number OS X El Capitan 10.11.0/10.11.1 Devices [Cannot distinguish between builds]" >> "${tmplocation}"/AlertInfo.txt
-echo "  $total10112number OS X El Capitan 10.11.2 Devices"
-echo "&nbsp;&nbsp; $total10112number OS X El Capitan 10.11.2 Devices" >> "${tmplocation}"/AlertInfo.txt
-echo "  $total10113number OS X El Capitan 10.11.3 Devices"
-echo "&nbsp;&nbsp; $total10113number OS X El Capitan 10.11.3 Devices" >> "${tmplocation}"/AlertInfo.txt
-echo "  $total10114number OS X El Capitan 10.11.4 Devices"
-echo "&nbsp;&nbsp; $total10114number OS X El Capitan 10.11.4 Devices" >> "${tmplocation}"/AlertInfo.txt
-echo "  $total10115number OS X El Capitan 10.11.5 Devices"
-echo "&nbsp;&nbsp; $total10115number OS X El Capitan 10.11.5 Devices" >> "${tmplocation}"/AlertInfo.txt
+echo "A total of $totalosxnumber OS X devices hit the Caching Server yesterday consisting of:" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "  $total10100number OS X Yosemite 10.10.0/10.10.1 Devices [Cannot distinguish between builds]" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "  $total10102number OS X Yosemite 10.10.2 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "  $total10103number OS X Yosemite 10.10.3 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "  $total10104number OS X Yosemite 10.10.4 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "  $total10105number OS X Yosemite 10.10.5 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "  $total10110number OS X El Capitan 10.11.0/10.11.1 Devices [Cannot distinguish between builds]" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "  $total10112number OS X El Capitan 10.11.2 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "  $total10113number OS X El Capitan 10.11.3 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "  $total10114number OS X El Capitan 10.11.4 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "  $total10115number OS X El Capitan 10.11.5 Devices" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 echo 
-echo  " " >> "${tmplocation}"/AlertInfo.txt
+echo  " " 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 
 # Stage VI: Apple Configurator 2
 ## Anything containing the phrase "%Configurator" means it is Configurator 2 related. Read the merged log and output to new file
@@ -784,12 +651,10 @@ totalac200number=`wc -l "${tmplocation}"/Total_AC_2.0.txt | awk '{print $1}'`
 
 
 ## Output Darwin data.
-echo A total of $totalacnumber Applications were downloaded from Apple Configurator 2 devices, consisting of:
-echo "A total of $totalacnumber Applications were downloaded from Apple Configurator 2 devices, consisting of:" >> "${tmplocation}"/AlertInfo.txt
-echo "  $totalac200number Applications downloaded from Apple Configurator 2.0/2.1/2.2 [Cannot distinguish between builds]"
-echo "&nbsp;&nbsp; $totalac200number Applications downloaded from Apple Configurator 2.0/2.1/2.2 [Cannot distinguish between builds]" >> "${tmplocation}"/AlertInfo.txt
+echo "A total of $totalacnumber Applications were downloaded from Apple Configurator 2 devices, consisting of:" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "  $totalac200number Applications downloaded from Apple Configurator 2.0/2.1/2.2 [Cannot distinguish between builds]" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 echo 
-echo  " " >> "${tmplocation}"/AlertInfo.txt
+echo  " " 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 
 # Stage VII: Extract URL's from log file, output into file and remove duplicates.
 ## Anything containing the phrase " http" means it is download related. Read the merged log and output to new file
@@ -818,22 +683,15 @@ totalepubnumber=`wc -l "${tmplocation}"/Total_Books.txt | awk '{print $1}'`
 totalsregistersnumber=`wc -l "${tmplocation}"/Total_Server_Registers.txt | awk '{print $1}'`
 
 ## Output data.
-echo A total of $totalurlnumber files were downloaded from the Caching Server yesterday consisting of:
-echo "A total of $totalurlnumber files were downloaded from the Caching Server yesterday consisting of:" >> "${tmplocation}"/AlertInfo.txt
-echo "  $totalepubnumber Books"
-echo "&nbsp;&nbsp; $totalepubnumber Books" >> "${tmplocation}"/AlertInfo.txt
-echo "  $totalipanumber iOS Apps"
-echo "&nbsp;&nbsp; $totalipanumber iOS Apps" >> "${tmplocation}"/AlertInfo.txt
-echo "  $totalpkgnumber Mac Apps"
-echo "&nbsp;&nbsp; $totalpkgnumber Mac Apps" >> "${tmplocation}"/AlertInfo.txt
-echo "  $totalzipnumber Zip files"
-echo "&nbsp;&nbsp; $totalzipnumber Zip files" >> "${tmplocation}"/AlertInfo.txt
-echo "  $totalipswnumber IPSW files"
-echo "&nbsp;&nbsp; $totalipswnumber IPSW files" >> "${tmplocation}"/AlertInfo.txt
-echo "  $totalsregistersnumber Apple Server Registrations"
-echo "&nbsp;&nbsp; $totalsregistersnumber Apple Server Registrations" >> "${tmplocation}"/AlertInfo.txt
+echo "A total of $totalurlnumber files were downloaded from the Caching Server yesterday consisting of:" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "  $totalepubnumber Books" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "  $totalipanumber iOS Apps" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "  $totalpkgnumber Mac Apps" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "  $totalzipnumber Zip files" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "  $totalipswnumber IPSW files" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "  $totalsregistersnumber Apple Server Registrations" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 echo 
-echo  " " >> "${tmplocation}"/AlertInfo.txt
+echo  " " 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 
 ## Load txt file, sort it and delete any duplicate URL's to get your unique URL number.
 cat "${tmplocation}"/Total_URLs.txt | sort | uniq > "${tmplocation}"/Unique_URLs.txt
@@ -857,23 +715,27 @@ uniquezipnumber=`wc -l "${tmplocation}"/Unique_Zips.txt | awk '{print $1}'`
 uniqueipswnumber=`wc -l "${tmplocation}"/Unique_IPSWs.txt | awk '{print $1}'`
 
 ## Output data.
-echo $uniqueurlnumber Unique files were downloaded from the Caching Server yesterday consisting of:
-echo "$uniqueurlnumber Unique files were downloaded from the Caching Server yesterday consisting of:" >> "${tmplocation}"/AlertInfo.txt
-echo "  $uniqueepubnumber Unique Books"
-echo "&nbsp;&nbsp; $uniqueepubnumber Unique Books" >> "${tmplocation}"/AlertInfo.txt
-echo "  $uniqueipanumber Unique iOS Apps"
-echo "&nbsp;&nbsp; $uniqueipanumber Unique iOS Apps" >> "${tmplocation}"/AlertInfo.txt
-echo "  $uniquepkgnumber Unique Mac Apps"
-echo "&nbsp;&nbsp; $uniquepkgnumber Unique Mac Apps" >> "${tmplocation}"/AlertInfo.txt
-echo "  $uniquezipnumber Unique Zip files"
-echo "&nbsp;&nbsp; $uniquezipnumber Unique Zip files" >> "${tmplocation}"/AlertInfo.txt
-echo "  $uniqueipswnumber Unique IPSW files"
-echo "&nbsp;&nbsp; $uniqueipswnumber Unique IPSW files" >> "${tmplocation}"/AlertInfo.txt
-echo
-echo  " " >> "${tmplocation}"/AlertInfo.txt
+echo "$uniqueurlnumber Unique files were downloaded from the Caching Server yesterday consisting of:" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "  $uniqueepubnumber Unique Books" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "  $uniqueipanumber Unique iOS Apps" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "  $uniquepkgnumber Unique Mac Apps" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "  $uniquezipnumber Unique Zip files" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo "  $uniqueipswnumber Unique IPSW files" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo  " " 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+
+# Add script/report version
+echo  " " 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo  "Cacher version: $version" 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
+echo  " " 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt
 
 # Stage IX: Server Alert
 # iconv -f US-ASCII -t UTF-8 "${tmplocation}"/AlertInfo.txt > "${tmplocation}"/AlertInfoUTF.txt
+# Replaces prefixed spaces with &nbsp; + 1 additional space to match previous version(s) of Cacher
+sed -i -e 's/^     /\&nbsp\;\&nbsp\;\&nbsp\;\&nbsp\;\&nbsp\; /' "${tmplocation}"/AlertInfo.txt
+sed -i -e 's/^    /\&nbsp\;\&nbsp\;\&nbsp\;\&nbsp\; /' "${tmplocation}"/AlertInfo.txt
+sed -i -e 's/^   /\&nbsp\;\&nbsp\;\&nbsp\; /' "${tmplocation}"/AlertInfo.txt
+sed -i -e 's/^  /\&nbsp\;\&nbsp\; /' "${tmplocation}"/AlertInfo.txt
+sed -i -e 's/^ /\&nbsp\; /' "${tmplocation}"/AlertInfo.txt
 # Send alert through Server.app
 finalalert=`echo | grep "" "${tmplocation}"/AlertInfo.txt`
 /Applications/Server.app/Contents/ServerRoot/usr/sbin/server postAlert CustomAlert Common subject "Caching Server Data: $yesterday" message "$finalalert" <<<""


### PR DESCRIPTION
- Simplifies code by removing repetitive echo (echo to screen + echo to file); replaces repetitive echo with tee as suggested by @hunty1 on PR 18 ( 2>&1 | tee -a "${tmplocation}"/AlertInfo.txt).  Previously, Cacher was 882 lines of code, this change brings it down to 744 and is easier to read and modify.
- Adds Uptime to emailed report.
- Adjusts Last Modified date from 05/16/2016 (inaccurate) to 9/23/2016.
- Adds a script version, randomly started at 2.0. I assume that's a good point to start incrementing the script version for all future PR's and updates.
  - Adds script version to the bottom of the emailed alert for reference when comparing reports.
